### PR TITLE
fix the function of submask_masktoprefix bug in windows

### DIFF
--- a/build/autogen_lib.sh
+++ b/build/autogen_lib.sh
@@ -13,32 +13,14 @@ VERSION_SH=version.sh
 
 LIBFOO_MACRO=`echo ${MODULE} | tr 'a-z' 'A-Z'`
 
+LPWD=$(dirname `readlink -f $0`)
+
 YEAR=$(date '+%Y')
 S='$'
 exclamation='!'
 
-LICENSE_HEADER=\
-"/******************************************************************************
- * Copyright (C) 2014-2020 Zhifeng Gong <gozfree@163.com>
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- ******************************************************************************/"
+LICENSE_HEADER=license_header.inc
+
 usage()
 {
 	echo "==== usage ===="
@@ -54,8 +36,8 @@ mkdir_libfoo()
 
 autogen_libfoo_h()
 {
-cat > ${LIBFOO_H} <<!
-${LICENSE_HEADER}
+cat ${LPWD}/${LICENSE_HEADER} > ${LIBFOO_H}
+cat >> ${LIBFOO_H} <<!
 #ifndef ${LIBFOO_MACRO}_H
 #define ${LIBFOO_MACRO}_H
 
@@ -74,8 +56,8 @@ extern "C" {
 
 autogen_libfoo_c()
 {
-cat > ${LIBFOO_C} <<!
-${LICENSE_HEADER}
+cat ${LPWD}/${LICENSE_HEADER} > ${LIBFOO_C}
+cat >> ${LIBFOO_C} <<!
 #include "${LIBFOO_H}"
 #include <stdio.h>
 #include <stdlib.h>
@@ -85,8 +67,8 @@ ${LICENSE_HEADER}
 
 autogen_test_libfoo_c()
 {
-cat > ${TEST_LIBFOO_C} <<!
-${LICENSE_HEADER}
+cat ${LPWD}/${LICENSE_HEADER} > ${TEST_LIBFOO_C}
+cat >> ${TEST_LIBFOO_C} <<!
 #include "${LIBFOO_H}"
 #include <stdio.h>
 #include <stdlib.h>

--- a/build/license_header.inc
+++ b/build/license_header.inc
@@ -1,0 +1,21 @@
+/******************************************************************************
+ * Copyright (C) 2014-2020 Zhifeng Gong <gozfree@163.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ ******************************************************************************/

--- a/libsubmask/libsubmask.c
+++ b/libsubmask/libsubmask.c
@@ -36,10 +36,10 @@ int submask_masktoprefix(const char* ip_str)
 {
     //int ret = 0;
     unsigned int ip_num = 0;
-    unsigned char c1,c2,c3,c4;
+    unsigned int c1,c2,c3,c4;
     int cnt = 0;
 		int i = 0;
-    sscanf(ip_str, "%hhu.%hhu.%hhu.%hhu", &c1, &c2, &c3, &c4);
+    sscanf(ip_str, "%u.%u.%u.%u", &c1, &c2, &c3, &c4);
     ip_num = c1<<24 | c2<<16 | c3<<8 | c4;
 
     // fast...

--- a/libsubmask/test_libsubmask.c
+++ b/libsubmask/test_libsubmask.c
@@ -97,8 +97,8 @@ int foo1()
 {
 	char ipbuf[56];
 	printf("foo1 submask_masktoprefix mask:%s ===> prefix:%d\n","255.255.255.128",submask_masktoprefix("255.255.255.128"));
-	submask_prefixtomask(16,ipbuf);
-	printf("foo1 submask_prefixtomask prefix:%d ===> mask:%s\n",16,ipbuf);
+	submask_prefixtomask(25,ipbuf);
+	printf("foo1 submask_prefixtomask prefix:%d ===> mask:%s\n",25,ipbuf);
 	return 0;
 }
 


### PR DESCRIPTION
fix submask_masktoprefix run exception in windows return mask for zero