### PR TITLE
Fix unbounded write

### DIFF
--- a/gear-lib/libfile/filewatcher.c
+++ b/gear-lib/libfile/filewatcher.c
@@ -175,7 +175,7 @@ int fw_update_watch(struct fw *fw, struct inotify_event *iev)
         return -1;
     }
     memset(full_path, 0, sizeof(full_path));
-    sprintf(full_path, "%s/%s", path, iev->name);
+    snprintf(full_path, sizeof(full_path), "%s/%s", path, iev->name);
     if (iev->mask & IN_CREATE) {
         if (iev->mask & IN_ISDIR) {
             fw_add_watch_recursive(fw, full_path);

--- a/gear-lib/libsock/test_libsock.c
+++ b/gear-lib/libsock/test_libsock.c
@@ -188,7 +188,7 @@ int main(int argc, char **argv)
         while (1) {
             memset(buf, 0, sizeof(buf));
             printf("input> ");
-            scanf("%s", buf);
+            scanf("%63s", buf);
             printf("%s:%d fd=%d\n", __func__, __LINE__, sc->fd);
             n = sock_send(sc->fd, buf, strlen(buf));
             if (n == -1) {


### PR DESCRIPTION
1. Use snprintf() instead of sprintf()
2. Specify max field width for "%s" in scanf()