### PR TITLE
Use size of destination as third argument of strncpy()

### DIFF
--- a/gear-lib/libthread/libthread.c
+++ b/gear-lib/libthread/libthread.c
@@ -149,7 +149,7 @@ int thread_set_name(struct thread *t, const char *name)
         printf("pthread_setname_np %s failed: %d\n", name, errno);
         return -1;
     }
-    strncpy(t->name, name, strlen(name));
+    strncpy(t->name, name, sizeof(t->name));
     return 0;
 #else
     return 0;


### PR DESCRIPTION
Calling 'strncpy' with the size of the source buffer as the third argument may result in a buffer overflow.