### PR TITLE
[libposix,libdebug] fix compile issue

### DIFF
--- a/gear-lib/libdebug/libdebug.c
+++ b/gear-lib/libdebug/libdebug.c
@@ -148,7 +148,7 @@ static void backtrace_symbols_detail(void *array[], int size)
     for (i = 1; i < size; ++i) {//from 1, ignore this file info
         fprintf(fp, "%p\n", array[i]);
     }
-    fclose(fp);
+    pclose(fp);
 }
 #endif
 

--- a/gear-lib/libposix/libposix.h
+++ b/gear-lib/libposix/libposix.h
@@ -271,8 +271,8 @@ struct reflect {
     void_fn fn;
     const char* name;
 };
-struct reflect __start_reflect;
-struct reflect __stop_reflect;
+extern struct reflect __start_reflect;
+extern struct reflect __stop_reflect;
 
 #define REFLECT_DEF(x) __attribute__((section("reflect"), aligned(sizeof(void*)))) \
             struct reflect __##x = {(void_fn)x, #x};


### PR DESCRIPTION
When I tried to compile on my Ubuntu 22.04, I found that the compilation did not work and there were two compilation issues.
1. Redefine the symbol __start_deflex, I think it was already defined by the linker when creating the segment.
2. Is it a typographical error or is there another reason why popen opened the handle but used fclose.